### PR TITLE
Add optional QEMU support

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,27 @@
                     "description": "The working directory where mocha is run (relative to the workspace folder)",
                     "type": "string",
                     "scope": "resource"
+                },
+                "gtestExplorer.useQemu": {
+                    "description": "Run Google tests under QEMU",
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "resource"
+                },
+                "gtestExplorer.qemuPath": {
+                    "description": "QEMU executable",
+                    "type": "string",
+                    "default": "qemu-system-arm",
+                    "scope": "resource"
+                },
+                "gtestExplorer.qemuArgs": {
+                    "description": "Arguments for QEMU before the test executable",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": ["-M", "versatilepb", "-m", "128M"],
+                    "scope": "resource"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `gtestExplorer.useQemu`, `qemuPath`, and `qemuArgs` settings
- support running and loading tests through QEMU in the adapter

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a21e121f4832696fec2271ecc8b47