### PR TITLE
Implement adapter disposal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,13 +24,14 @@ export async function activate(context: vscode.ExtensionContext) {
 	
 		vscode.workspace.onDidChangeWorkspaceFolders((event) => {
 	
-			for (const workspaceFolder of event.removed) {
-				const adapter = registeredAdapters.get(workspaceFolder);
-				if (adapter) {
-					testExplorerExtension.exports.unregisterAdapter(adapter);
-					registeredAdapters.delete(workspaceFolder);
-				}
-			}
+                        for (const workspaceFolder of event.removed) {
+                                const adapter = registeredAdapters.get(workspaceFolder);
+                                if (adapter) {
+                                        testExplorerExtension.exports.unregisterAdapter(adapter);
+                                        adapter.dispose();
+                                        registeredAdapters.delete(workspaceFolder);
+                                }
+                        }
 	
 			for (const workspaceFolder of event.added) {
 				const adapter = new GoogleTestAdapter(workspaceFolder);


### PR DESCRIPTION
## Summary
- store watchFile callback for later unwatching
- add `dispose()` to stop watching files and kill running processes
- dispose adapters when workspace folders are removed

## Testing
- `npx tsc --pretty false` *(fails: Cannot find type definition file for 'entities')*
- `npm install` *(failed: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687a2faf6af48326be19c63d58b86781