### PR TITLE
Fix load environment

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -60,7 +60,12 @@ export class GoogleTestAdapter implements TestAdapter {
                         const argsLoad = useQemu
                                 ? [...qemuArgs, executable, '--gtest_list_tests']
                                 : ['--gtest_list_tests'];
-                        execFile(cmdLoad, argsLoad, (error, stdout, stderr) => {
+                        const exec_options: ExecFileOptionsWithBufferEncoding = {
+                                cwd: this.getCwd(config),
+                                env: this.getEnv(config),
+                                encoding: 'buffer'
+                        };
+                        execFile(cmdLoad, argsLoad, exec_options, (error, stdout, stderr) => {
                                 if (error) {
                                         reject(error);
                                 } else {


### PR DESCRIPTION
## Summary
- ensure `load()` uses cwd and env just like `run()` so gtest discovery respects configuration

## Testing
- `npm run build` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a2fa62d3083269809b86e65ec4179