### PR TITLE
Fix environment variable removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This extension allows you to run your [Google tests](https://github.com/google/g
 ## Configuration
 
 * `gtestExplorer.executable`: The relative path describing the location of your test executable (relative to the workspace folder)
-* `gtestExplorer.env`: Environment variables to be set when running the tests
+* `gtestExplorer.env`: Environment variables to be set when running the tests. Set a variable to `null` or `undefined` to remove it from the test environment.
 * `gtestExplorer.cwd`: The working directory where Google is run (relative to the workspace folder)
 * `gtestExplorer.useQemu`: Run Google tests under QEMU
 * `gtestExplorer.qemuPath`: QEMU executable path

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -253,11 +253,11 @@ export class GoogleTestAdapter implements TestAdapter {
 
 		for (const prop in configEnv) {
 			const val = configEnv[prop];
-			if ((val === undefined) || (val === null)) {
-				delete resultEnv.prop;
-			} else {
-				resultEnv[prop] = String(val);
-			}
+                        if ((val === undefined) || (val === null)) {
+                                delete resultEnv[prop];
+                        } else {
+                                resultEnv[prop] = String(val);
+                        }
 		}
 
 		return resultEnv;


### PR DESCRIPTION
## Summary
- allow removing environment variables via `null` or `undefined`
- document env variable removal in README

## Testing
- `npm run build` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_687a2fa243bc8326aa45dc0330e9139f